### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# status [![Current Version](https://pypip.in/version/status/badge.svg?text=version&style=flat)](https://pypi.python.org/pypi/status/) [![License](https://pypip.in/license/status/badge.svg?style=flat)](https://github.com/chrissimpkins/status/blob/master/docs/LICENSE)
+# status [![Current Version](https://img.shields.io/pypi/v/status.svg?label=version&style=flat)](https://pypi.python.org/pypi/status/) [![License](https://img.shields.io/pypi/l/status.svg?style=flat)](https://github.com/chrissimpkins/status/blob/master/docs/LICENSE)
 
 
 ### HTTP status codes for GET and POST requests


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20status))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `status`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.